### PR TITLE
changement du if installation composer

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -13,7 +13,7 @@ RUN docker-php-ext-install zip
 RUN docker-php-ext-enable apcu
 
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'baf1608c33254d00611ac1705c1d9958c817a1a33bce370c0595974b342601bd80b92a3f46067da89e3b06bff421f182') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+    && php -r "if (hash_file('sha384', 'composer-setup.php') === 'c5b9b6d368201a9db6f74e2611495f369991b72d9c8cbd3ffbc63edff210eb73d46ffbfce88669ad33695ef77dc76976') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
     && php composer-setup.php --filename=composer \
     && php -r "unlink('composer-setup.php');" \
     && mv composer /usr/local/bin/composer


### PR DESCRIPTION
https://getcomposer.org/download/
J'ai l'impression que le resultat du SHA384 du composer download est différent du tiens et ça me créait un crash de l'install.
Sur la plupart des projets que j'ai croisé, ils laissent toute la partie vendor et composer sur la machine pour éviter le chargement de toutes les dépendances a chaque up.
